### PR TITLE
[#40] Fix ODD2018 tweets datapackage and add it to be validated

### DIFF
--- a/goodtables.yml
+++ b/goodtables.yml
@@ -34,6 +34,7 @@ datapackages:
   - inflation/datapackage.json
 #  - iso-639-1-language-codes/datapackage.json  Language pattern not implemented in Goodtables.io
   - periodic-table/datapackage.json
+  - open-data-day-tweets-2018/datapackage.json
 #  - simple-geojson/datapackage.json     Goodtables only validates tabular data
 #  - world-continents-topojson/datapackage.json    Goodtables only validates tabular data
 #  - text-file/datapackage.json    .txt file format not supported by Goodtables.io

--- a/open-data-day-tweets-2018/datapackage.json
+++ b/open-data-day-tweets-2018/datapackage.json
@@ -35,6 +35,17 @@
   "description": "A stripped-down version of open data day data mined from Twitter in March 2018. Data Brevity is as a result of  Twitter's Developer Policy.",
   "homepage": "https://okfnlabs.org/blog/2018/03/08/open-data-day-tweets.html",
   "version": "1.0.0",
-  "license": "Twitter Developer Policy",
-  "author": "Serah Rono <serah.rono@okfn.org> (https://twitter.com/serahrono)"
+  "licenses": [
+    {
+      "title": "Twitter Developer Agreement",
+      "path": "https://developer.twitter.com/en/developer-terms/agreement"
+    }
+  ],
+  "contributors": [
+    {
+      "title": "Serah Rono",
+      "path": "https://twitter.com/serahrono",
+      "role": "author"
+    }
+  ]
 }


### PR DESCRIPTION
@Stephen-Gates I made the fixes you pointed on #40, but there's a problem with the `licenses`. According to the spec, its name must be an [Open Definition license ID](http://licenses.opendefinition.org/), but how to handle this case? Do I need to apply to add twitter's developer agreement as a license ID? That sounds very cumbersome when packaging data that doesn't use a standard license.